### PR TITLE
Add Ubuntu Docker Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ PATH=$PATH:/usr/local/bin
 wget -O - https://raw.githubusercontent.com/wmarinho/edw_cenipa/master/easy_install | sh
 ```
 
+### Instalação rápida do Docker no Ubuntu Server 14.04
+
+```
+sudo wget https://raw.githubusercontent.com/it4biz/ubuntu-docker-installer/master/ubuntu-docker-installer.sh
+sh ubuntu-docker-installer.sh
+```
+
+
+
 ### Verificar execução dos containers
 ```
 $ docker ps


### PR DESCRIPTION
Wellington,

I added a Docker Installer for Ubuntu 14.04, because for Ubuntu Users we have to do more commands to install Docker and Docker Compose.
